### PR TITLE
Fixing issue with unknown properties and stopAtFirstUnknown

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -35,7 +35,11 @@ export function parse<T, P extends ParseOptions<T> = ParseOptions<T>>(
     let parsedArgs = commandLineArgs(optionList, options) as any;
 
     if (parsedArgs['_all'] != null) {
+        const unknown = parsedArgs['_unknown'];
         parsedArgs = parsedArgs['_all'];
+        if (unknown) {
+            parsedArgs['_unknown'] = unknown;
+        }
     }
 
     const booleanValues = getBooleanValues(argsWithBooleanValues, normalisedConfig);


### PR DESCRIPTION
When using argument groups, `command-line-args::parse` returns an object with the arguments added into groups. `ts-command-line-args` ignores every group except for `_all`, which makes sense, but doesn't work when also trying to use `stopAtFirstUnknown`. This change simply adds the `_unknown` arguments back in this case, and adds some test cases to cover the issue.