### PR TITLE
feat: add option for process exit code

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -203,6 +203,11 @@ export interface ArgsParseOptions<T extends { [name: string]: any }> extends Usa
      * prepends the supplied description with details about the param. These include default option, optional and the default value.
      */
     prependParamOptionsToDescription?: boolean;
+
+    /**
+     * sets the exit code of the process. Defaults to 0.
+     */
+    processExitCode: number;
 }
 
 export interface PartialParseOptions extends ArgsParseOptions<any> {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -207,7 +207,7 @@ export interface ArgsParseOptions<T extends { [name: string]: any }> extends Usa
     /**
      * sets the exit code of the process. Defaults to 0.
      */
-    processExitCode: number;
+    processExitCode?: number;
 }
 
 export interface PartialParseOptions extends ArgsParseOptions<any> {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -80,7 +80,7 @@ export function parse<T, P extends ParseOptions<T> = ParseOptions<T>, R extends 
         printHelpGuide(options, optionList, logger);
 
         if (exitProcess) {
-            return process.exit();
+            return process.exit(options.processExitCode ?? 0);
         }
     } else if (missingArgs.length > 0) {
         if (options.showHelpWhenArgsMissing) {
@@ -105,7 +105,7 @@ export function parse<T, P extends ParseOptions<T> = ParseOptions<T>, R extends 
     };
 
     if (missingArgs.length > 0 && exitProcess) {
-        process.exit();
+        process.exit(options.processExitCode ?? 0);
     } else {
         if (addCommandLineResults) {
             parsedArgs = { ...parsedArgs, _commandLineResults };


### PR DESCRIPTION
Adds exit code for process. Currently, it exits with error code 0.