### PR TITLE
Fix path/URI conversion (SO 77980517)

### DIFF
--- a/src/helpers/markdown.helper.ts
+++ b/src/helpers/markdown.helper.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 import { normaliseConfig, createCommandLineConfig } from './command-line.helper.js';
 import { generateTableFooter, getOptionSections, mapDefinitionDetails } from './options.helper.js';
 import { convertChalkStringToMarkdown } from './string.helper.js';
+import { pathToFileURL } from 'url';
 
 export function createUsageGuide<T = any>(config: UsageGuideConfig<T>): string {
     const options = config.parseOptions || {};
@@ -167,7 +168,7 @@ export async function generateUsageGuides(args: IWriteMarkDown): Promise<string[
 export async function loadArgConfig(jsFile: string, importName: string): Promise<UsageGuideConfig | undefined> {
     const jsPath = join(process.cwd(), jsFile);
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsExports = await import(jsPath);
+    const jsExports = await import(pathToFileURL(jsPath).href);
 
     const argConfig: UsageGuideConfig = jsExports[importName];
 

--- a/src/write-markdown.ts
+++ b/src/write-markdown.ts
@@ -8,12 +8,11 @@ import { addCommandLineArgsFooter, addContent, generateUsageGuides, insertCode }
 import { argumentConfig, parseOptions } from './write-markdown.constants.js';
 import format from 'string-format';
 import chalk from 'chalk';
-import { pathToFileURL } from "url"
 
 async function writeMarkdown() {
     const args = parse<IWriteMarkDown>(argumentConfig, parseOptions);
 
-    const markdownPath = pathToFileURL(resolve(args.markdownPath)).href;
+    const markdownPath = resolve(args.markdownPath);
 
     console.log(`Loading existing file from '${chalk.blue(markdownPath)}'`);
     const markdownFileContent = readFileSync(markdownPath).toString();


### PR DESCRIPTION
Fixes incorrect path-to-URI conversion as part of move to ESM modules.

See explanation at https://stackoverflow.com/questions/77980517/having-trouble-using-readfilesync-with-esm-modules-on-nodejs/77982126#77982126